### PR TITLE
Fixes to make_csv.py to more accurately filter EventItems, including:

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -1,0 +1,13 @@
+name: "Build legacy Nix package on Ubuntu"
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - name: Building package
+        run: nix-build . -A defaultPackage.x86_64-linux

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+secrets.py
+runs
+.ipynb_*
+*.csv
+.direnv

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1660396586,
+        "narHash": "sha256-ePuWn7z/J5p2lO7YokOG1o01M0pDDVL3VrStaPpS5Ig=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e105167e98817ba9fe079c6c3c544c6ef188e276",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660396586,
-        "narHash": "sha256-ePuWn7z/J5p2lO7YokOG1o01M0pDDVL3VrStaPpS5Ig=",
+        "lastModified": 1694669921,
+        "narHash": "sha256-6ESpJ6FsftHV96JO/zn6je07tyV2dlLR7SdLsmkegTY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e105167e98817ba9fe079c6c3c544c6ef188e276",
+        "rev": "f2ea252d23ebc9a5336bf6a61e0644921f64e67c",
         "type": "github"
       },
       "original": {
@@ -22,13 +22,31 @@
         "utils": "utils"
       }
     },
-    "utils": {
+    "systems": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
 
         devShell = pkgs.mkShell {
             buildInputs = with pkgs; [
-                python3Packages.poetry
+                python3Packages.poetry-core
                 python3Packages.requests
                 python3Packages.pytz
                 python3Packages.oauthlib

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+    inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+        utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = {self, nixpkgs, utils}:
+    let out = system:
+    let pkgs = nixpkgs.legacyPackages."${system}";
+    in {
+
+        devShell = pkgs.mkShell {
+            buildInputs = with pkgs; [
+                python3Packages.poetry
+                python3Packages.requests
+                python3Packages.pytz
+                python3Packages.oauthlib
+                python3Packages.beautifulsoup4
+                jq
+            ];
+        };
+
+        defaultPackage = with pkgs.poetry2nix; mkPoetryApplication {
+            projectDir = ./.;
+            preferWheels = true;
+        };
+
+        defaultApp = utils.lib.mkApp {
+            drv = self.defaultPackage."${system}";
+        };
+
+    }; in with utils.lib; eachSystem defaultSystems out;
+
+}

--- a/make_csv.py
+++ b/make_csv.py
@@ -4,6 +4,7 @@ import logging
 import json
 import re
 import sys
+from types import NoneType
 
 import council_twitter_bot
 
@@ -82,8 +83,8 @@ def get_class(ei):
         # skip this one, it's not interesting
         return None
 
-    if not ei["EventItemActionName"].startswith("Approved"):
-        event_class_items.append("amendment")
+    if ei["EventItemActionName"] is not None and not ei["EventItemActionName"].startswith("Approved"):
+            event_class_items.append("amendment")
 
     if voting_result:
         event_class_items.append("pass")

--- a/make_csv.py
+++ b/make_csv.py
@@ -71,7 +71,7 @@ def get_class(ei):
     elif re.match(r"CA-\d+", ei["EventItemAgendaNumber"]) or ei["EventItemConsent"]:
         event_class_items.append("consent")
         if not ei["EventItemConsent"]:
-            event_class_items.append("pulled")
+            event_class_items.append("rollcall")
     elif matter_type == "Ordinance":
         event_class_items.append("ordinance")
     elif matter_type == "Resolution" or matter_type == "Resolution/Public Hearing":

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
Multiple fixes to make_csv.py to improve its accuracy in filtering and determining voting results from EventItems, including:
- Relying primarily on the EventItemMatterType field, instead of EventItemAgendaNumber, to determine whether an item should be included, and which classes to apply to it. (We still use EventItemAgendaNumber to identify pulled consent-agenda items).
- Treating un-pulled consent-agenda items as having been approved if they are missing an EventItemPassedFlag field
- Assuming "Amended" actions without an EventItemPassedFlag field were approved as "friendly" amendments
- Keeping track of which members are absent for voice votes using the "Roll Call" (i.e. attendance-taking) EventItems
